### PR TITLE
validate note method implementation

### DIFF
--- a/lib/errbit_plugin/validate_issue_tracker.rb
+++ b/lib/errbit_plugin/validate_issue_tracker.rb
@@ -27,7 +27,7 @@ module ErrbitPlugin
     end
 
     def implement_method?
-      [:comments_allowed?, :label, :fields, :configured?, :check_params, :create_issue, :url].all? do |method|
+      [:comments_allowed?, :label, :fields, :configured?, :check_params, :create_issue, :url, :note].all? do |method|
         if instance.respond_to?(method)
           true
         else

--- a/spec/errbit_plugin/validate_issue_tracker_spec.rb
+++ b/spec/errbit_plugin/validate_issue_tracker_spec.rb
@@ -196,5 +196,27 @@ describe ErrbitPlugin::ValidateIssueTracker do
         expect(is.errors).to eql [[:method_missing, :comments_allowed?]]
       end
     end
+
+    context "without note method" do
+      class BazNote < ErrbitPlugin::IssueTracker
+        def label; 'foo'; end
+        def fields; ['foo']; end
+        def configured?; true; end
+        def check_params; true; end
+        def create_issue; 'http'; end
+        def url; 'foo'; end
+        def comments_allowed?; false; end
+      end
+
+      it 'not valid' do
+        expect(ErrbitPlugin::ValidateIssueTracker.new(BazNote).valid?).to be_false
+      end
+
+      it 'say not implement comments_allowed?' do
+        is = ErrbitPlugin::ValidateIssueTracker.new(BazNote)
+        is.valid?
+        expect(is.errors).to eql [[:method_missing, :note]]
+      end
+    end
   end
 end


### PR DESCRIPTION
The note method is actually required because it's called by IssueTrackerDecorator#note:
https://github.com/errbit/errbit/blob/features/extract_issue_tracker/app/decorators/issue_tracker_decorator.rb#L18-L20
